### PR TITLE
Add vendorsetup.sh; correct prebuilt kernel directory

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -37,7 +37,7 @@ BOARD_RAMDISK_OFFSET := 0x15000000
 BOARD_TAGS_OFFSET := 0x14000000
 BOARD_KERNEL_CMDLINE := bootopt=64S3,32S1,32S1 androidboot.selinux=permissive androidboot.configfs=true
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_TAGS_OFFSET)
-TARGET_PREBUILT_KERNEL := device/xiaomi/cactus/prebuilt/kernel
+TARGET_PREBUILT_KERNEL := device/xiaomi/cereus/prebuilt/kernel
 
 # Recovery
 BOARD_HAS_NO_SELECT_BUTTON := true

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,0 +1,1 @@
+add_lunch_combo omni_cereus-userdebug


### PR DESCRIPTION
Resolves some issues: 
- Cannot add device with `lunch`
- Compilation fails if `cactus` tree is not present

_small note : kernel source is present at [here](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cactus-o-oss). Should we move to self-compiled kernels instead of prebuilts ?_